### PR TITLE
Add Interface FileEncDecryptorRetriever to activate crypto via non-API

### DIFF
--- a/parquet-hadoop/src/main/java/org/apache/parquet/crypto/CryptoClassLoader.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/crypto/CryptoClassLoader.java
@@ -1,0 +1,85 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.parquet.crypto;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.parquet.hadoop.BadConfigurationException;
+import org.apache.parquet.hadoop.util.ConfigurationUtil;
+
+import java.io.IOException;
+
+import static org.apache.parquet.Preconditions.checkNotNull;
+
+public class CryptoClassLoader {
+
+  public static final String CRYPTO_METADATA_RETRIEVER_CLASS  = "parquet.crypto.encryptor.decryptor.retriever.class";
+
+  public static boolean metadataRetrieverExists(Configuration configuration) {
+    return configuration.get(CRYPTO_METADATA_RETRIEVER_CLASS) != null;
+  }
+
+  /**
+   * Calling user configured class to create encryptor
+   * @param conf Hadoop configuration
+   * @return
+   * @throws IOException
+   */
+  public static ParquetFileEncryptor getParquetFileEncryptorOrNull(Configuration conf) throws IOException {
+    FileEncDecryptorRetriever fileEncDecryptorRetriever = getFileEncDecryptorRetriever(conf);
+    return fileEncDecryptorRetriever.getFileEncryptor(conf);
+  }
+
+  /**
+   * Calling user configured class to create decryptor
+   * @param conf Hadoop configuration
+   * @return
+   * @throws IOException
+   */
+  public static ParquetFileDecryptor getParquetFileDecryptorOrNull(Configuration conf) throws IOException {
+    FileEncDecryptorRetriever fileEncDecryptorRetriever = getFileEncDecryptorRetriever(conf);
+    return fileEncDecryptorRetriever.getFileDecryptor(conf);
+  }
+
+  /**
+   * If CRYPTO_METADATA_RETRIEVER_CLASS exists in configuration, the relative class will be invoked.
+   * The class should implement the interface of FileEncDecryptorRetriever.
+   *
+   * @param configuration to find the configuration for the write support class
+   * @return the configured crypto metadata retriever(FileEncDecryptorRetriever)
+   */
+  @SuppressWarnings("unchecked")
+  public static FileEncDecryptorRetriever getFileEncDecryptorRetriever(Configuration configuration){
+    if (! metadataRetrieverExists(configuration)) {
+      return null;
+    }
+
+    final Class<?> cryptoMetadataRetrieverClass = ConfigurationUtil.getClassFromConfig(configuration,
+                                                                                       CRYPTO_METADATA_RETRIEVER_CLASS,
+                                                                                       FileEncDecryptorRetriever.class);
+    try {
+        return (FileEncDecryptorRetriever)checkNotNull(cryptoMetadataRetrieverClass,
+                                              "cryptoMetadataRetrieverClass").newInstance();
+    } catch (InstantiationException | IllegalAccessException e) {
+        throw new BadConfigurationException("could not instantiate crypto metadata retriever class: "
+                                            + cryptoMetadataRetrieverClass, e);
+    }
+  }
+}
+

--- a/parquet-hadoop/src/main/java/org/apache/parquet/crypto/FileEncDecryptorRetriever.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/crypto/FileEncDecryptorRetriever.java
@@ -78,14 +78,6 @@ import org.apache.parquet.crypto.ParquetFileEncryptor;
 public interface FileEncDecryptorRetriever {
 
   /**
-   * Initialization of the object - For example, KMS client and Schema
-   * initialization can be done here.
-   *
-   * @param conf Configuration of running task
-   */
-  //void initialize(Configuration conf) throws IOException;
-
-  /**
    * Get the file encryptor for encrypting parquet files.
    *
    * @param conf Configuration of running task

--- a/parquet-hadoop/src/main/java/org/apache/parquet/crypto/FileEncDecryptorRetriever.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/crypto/FileEncDecryptorRetriever.java
@@ -36,7 +36,7 @@ import org.apache.parquet.crypto.ParquetFileEncryptor;
  * as below.
  *
  * 1  Write a class to implement FileEncDecryptorRetriever. The sample implementation can be
- *    found http://xxxxxxxxxxxx.
+ *    found https://github.com/shangxinli/parquetcrytosampleretriever 
  *    1.1) To implement getFileEncryptor(), you need to create an instance of
  *       ParquetFileEncryptor and return it. To create that instance, you usually need
  *       to know each column of current schema of current writing

--- a/parquet-hadoop/src/main/java/org/apache/parquet/crypto/FileEncDecryptorRetriever.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/crypto/FileEncDecryptorRetriever.java
@@ -1,0 +1,116 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.parquet.crypto;
+
+import java.util.List;
+import java.io.IOException;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.parquet.schema.MessageType;
+import org.apache.parquet.crypto.ParquetFileDecryptor;
+import org.apache.parquet.crypto.ParquetFileEncryptor;
+
+/**
+ * This interface defines Parquet file encryptor and decryptor retriever defined in
+ * https://issues.apache.org/jira/browse/PARQUET-1325.
+ *
+ * This is for the non-API usage of Parquet crypto feature developed in
+ * https://issues.apache.org/jira/browse/PARQUET-1178. The usage is described
+ * as below.
+ *
+ * 1  Write a class to implement FileEncDecryptorRetriever. The sample implementation can be
+ *    found http://xxxxxxxxxxxx.
+ *    1.1) To implement getFileEncryptor(), you need to create an instance of
+ *       ParquetFileEncryptor and return it. To create that instance, you usually need
+ *       to know each column of current schema of current writing
+ *       and it's encryption properties like key, key metadata. These information usually
+ *       are stored outside current host and need to be retrieved. It is this class's
+ *       responsibility to retrieve all the needed information to be build up ParquetFileEncryptor.
+ *       But to retrieve them, it need to know the reference like ID of current schema. #3 below
+ *       describe how to pass the schema reference in configuration which is send back to
+ *       getFileEncryptor()
+ *
+ *    1.2) To implement getFileDecryptor(), you need to create an instance of
+ *       ParquetFileDecryptor and return it. To create that instance, you need to implement a
+ *       class to implement DecryptionKeyRetriever and create an instance of that class. As
+ *       metadata are embedded in the Parquet file, key retriever is the only thing needed.
+ *       The key retriever's method getKey() will be called by Parquet library during reading.
+ *
+ * 2  Set configuration of "parquet.crypto.encryptor.decryptor.retriever.class"
+ *    with the full namespace of this class. For example, we can set SparkSession as
+ *    below.
+ *
+ *    SparkSession spark = SparkSession
+ *                 .config("parquet.crypto.encryptor.decryptor.retriever.class",
+ *                         "org.apache.parquet.crypto.SampleFileEncDecryptorRetriever")
+ *
+ *    This class will be invoked by parquet library can call getFileEncryptor() or
+ *    getFileDecryptor() inside which you can create ParquetFileEncryptor or ParquetFileDecryptor.
+ *
+ * 3  For every write or read, set configuration to indicate the identity of
+ *    current schema. For example, you can set as below.
+ *
+ *    spark.sparkContext().hadoopConfiguration().set("schemaRef", "database1.table1");
+ *
+ *    Here, you can use other names too like "schemaId", "Id"... as long as it doesn't conflict
+ *    with others in current configuration. You class that implementation this interface
+ *    will need to get it back to reference current schema to create ParquetFileEncryptor or
+ *    ParquetFileDecryptor.
+ */
+
+public interface FileEncDecryptorRetriever {
+
+  /**
+   * Initialization of the object - For example, KMS client and Schema
+   * initialization can be done here.
+   *
+   * @param conf Configuration of running task
+   */
+  //void initialize(Configuration conf) throws IOException;
+
+  /**
+   * Get the file encryptor for encrypting parquet files.
+   *
+   * @param conf Configuration of running task
+   */
+  ParquetFileEncryptor getFileEncryptor(Configuration conf) throws IOException;
+
+  /**
+   * Get the file decryptor for decrypting parquet files.
+   *
+   * @param conf Configuration of running task
+   */
+  ParquetFileDecryptor getFileDecryptor(Configuration conf) throws IOException;
+
+  enum CryptoMode {
+    /**
+     * There is no encryption for footer or columns.
+     */
+    NONE,
+    /**
+     * Footer and all the columns are encrypted with same key.
+     */
+    UNIFORM,
+    /**
+     * Each column and footer can be encrypted with different key or not encrypted at all.
+     */
+    COLUMN
+  }
+}

--- a/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/ParquetOutputFormat.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/ParquetOutputFormat.java
@@ -1,4 +1,4 @@
-/* 
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -6,9 +6,9 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -18,6 +18,7 @@
  */
 package org.apache.parquet.hadoop;
 
+import static org.apache.parquet.crypto.CryptoClassLoader.getParquetFileEncryptorOrNull;
 import static org.apache.parquet.Preconditions.checkNotNull;
 import static org.apache.parquet.hadoop.ParquetWriter.DEFAULT_BLOCK_SIZE;
 import static org.apache.parquet.hadoop.util.ContextUtil.getConfiguration;
@@ -45,6 +46,9 @@ import org.apache.parquet.hadoop.util.ConfigurationUtil;
 import org.apache.parquet.hadoop.util.HadoopOutputFile;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.apache.parquet.crypto.ParquetFileEncryptor;
+import org.apache.parquet.crypto.FileEncDecryptorRetriever;
+import org.apache.parquet.crypto.CryptoClassLoader;
 
 /**
  * OutputFormat to write to a Parquet file
@@ -386,8 +390,12 @@ public class ParquetOutputFormat<T> extends FileOutputFormat<Void, T> {
     }
 
     WriteContext init = writeSupport.init(conf);
+
+    //Try to get encryptor from configured class. If not configured, null is returned.
+    ParquetFileEncryptor fileEncryptor = getParquetFileEncryptorOrNull(conf);
+
     ParquetFileWriter w = new ParquetFileWriter(HadoopOutputFile.fromPath(file, conf),
-        init.getSchema(), Mode.CREATE, blockSize, maxPaddingSize);
+        init.getSchema(), Mode.CREATE, blockSize, maxPaddingSize, fileEncryptor);
     w.start();
 
     float maxLoad = conf.getFloat(ParquetOutputFormat.MEMORY_POOL_RATIO,
@@ -414,7 +422,8 @@ public class ParquetOutputFormat<T> extends FileOutputFormat<Void, T> {
         validating,
         props,
         memoryManager,
-        conf);
+        conf,
+        fileEncryptor);
   }
 
   /**

--- a/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/ParquetRecordReader.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/ParquetRecordReader.java
@@ -18,6 +18,7 @@
  */
 package org.apache.parquet.hadoop;
 
+import static org.apache.parquet.crypto.CryptoClassLoader.getParquetFileDecryptorOrNull;
 import static org.apache.parquet.hadoop.ParquetInputFormat.SPLIT_FILES;
 
 import java.io.IOException;
@@ -160,7 +161,7 @@ public class ParquetRecordReader<T> extends RecordReader<Void, T> {
 
     // open a reader with the metadata filter
     ParquetFileReader reader = ParquetFileReader.open(
-        HadoopInputFile.fromPath(path, configuration), optionsBuilder.build());
+        HadoopInputFile.fromPath(path, configuration), optionsBuilder.build(), getParquetFileDecryptorOrNull(configuration));
 
     if (rowGroupOffsets != null) {
       // verify a row group was found for each offset

--- a/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/ParquetWriter.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/ParquetWriter.java
@@ -1,4 +1,4 @@
-/* 
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -6,9 +6,9 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -17,6 +17,8 @@
  * under the License.
  */
 package org.apache.parquet.hadoop;
+
+import static org.apache.parquet.crypto.CryptoClassLoader.getParquetFileEncryptorOrNull;
 
 import java.io.Closeable;
 import java.io.IOException;
@@ -54,7 +56,6 @@ public class ParquetWriter<T> implements Closeable {
 
   // max size (bytes) to write as padding and the min size of a row group
   public static final int MAX_PADDING_SIZE_DEFAULT = 8 * 1024 * 1024; // 8MB
-  
 
 
   private final InternalParquetRecordWriter<T> writer;
@@ -196,7 +197,7 @@ public class ParquetWriter<T> implements Closeable {
         compressionCodecName, blockSize, pageSize, dictionaryPageSize,
         enableDictionary, validating, writerVersion, conf);
   }
-  
+
   @Deprecated
   public ParquetWriter(
       Path file,
@@ -254,7 +255,7 @@ public class ParquetWriter<T> implements Closeable {
             .withWriterVersion(writerVersion)
             .build(), (ParquetFileEncryptor) null);
   }
-  
+
   @Deprecated
   public ParquetWriter(
       Path file,
@@ -321,6 +322,11 @@ public class ParquetWriter<T> implements Closeable {
 
     WriteSupport.WriteContext writeContext = writeSupport.init(conf);
     MessageType schema = writeContext.getSchema();
+
+    //Try to get encryptor from configured class. If not configured, null is returned.
+    if (fileEncryptor == null) {
+      fileEncryptor = getParquetFileEncryptorOrNull(conf);
+    }
 
     ParquetFileWriter fileWriter = new ParquetFileWriter(
         file, schema, mode, rowGroupSize, maxPaddingSize, fileEncryptor);
@@ -449,7 +455,7 @@ public class ParquetWriter<T> implements Closeable {
       this.codecName = codecName;
       return self();
     }
-    
+
     /**
      * Set the {@link ParquetFileEncryptor file encryptor} used by the
      * constructed writer.


### PR DESCRIPTION
This is the task of Parquet-1396. 

Parquet-1178 introduced the crypto feature to enable encryption for selective columns. However, the upper layer application need to call the new or modified APIs to use it. This could be a problem for existing services that running spark/hive/presto. 

Parquet-1396 introduced a non-API way to activate the crypto features by defining an interface and user can implement this interface as a plugin jar. 