### PR TITLE
add another decrypt method signature into interface Decryptor

### DIFF
--- a/parquet-format-structures/src/main/java/org/apache/parquet/format/BlockCipher.java
+++ b/parquet-format-structures/src/main/java/org/apache/parquet/format/BlockCipher.java
@@ -50,19 +50,6 @@ public interface BlockCipher{
      */
     public byte[] decrypt(byte[] lengthAndCiphertext, byte[] AAD) throws IOException;
     
-    /**
-     * Decrypts the ciphertext.
-     * Make sure the returned plaintext starts at offset 0 and and fills up the byte array.
-     * Input ciphertext starts at offset cipherTextOffset, and has a length of cipherTextLength.
-     * @param ciphertext
-     * @param cipherTextOffset
-     * @param cipherTextLength
-     * @param AAD
-     * @return
-     * @throws IOException
-     */
-    public byte[] decrypt(byte[] ciphertext, int cipherTextOffset, int cipherTextLength, byte[] AAD) throws IOException;
-
     public byte[] decryptInputStream(InputStream from, byte[] AAD) throws IOException;
   }
 }

--- a/parquet-format-structures/src/main/java/org/apache/parquet/format/BlockCipher.java
+++ b/parquet-format-structures/src/main/java/org/apache/parquet/format/BlockCipher.java
@@ -50,6 +50,19 @@ public interface BlockCipher{
      */
     public byte[] decrypt(byte[] lengthAndCiphertext, byte[] AAD) throws IOException;
     
+    /**
+     * Decrypts the ciphertext.
+     * Make sure the returned plaintext starts at offset 0 and and fills up the byte array.
+     * Input ciphertext starts at offset cipherTextOffset, and has a length of cipherTextLength.
+     * @param ciphertext
+     * @param cipherTextOffset
+     * @param cipherTextLength
+     * @param AAD
+     * @return
+     * @throws IOException
+     */
+    public byte[] decrypt(byte[] ciphertext, int cipherTextOffset, int cipherTextLength, byte[] AAD) throws IOException;
+
     public byte[] decryptInputStream(InputStream from, byte[] AAD) throws IOException;
   }
 }

--- a/parquet-hadoop/src/main/java/org/apache/parquet/format/converter/ParquetMetadataConverter.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/format/converter/ParquetMetadataConverter.java
@@ -1359,7 +1359,7 @@ public class ParquetMetadataConverter {
     return ret;
   }
 
-  private FileMetaData readFileMetaDataWithFilter(final InputStream from, MetadataFilter filter,
+  public FileMetaData readFileMetaDataWithFilter(final InputStream from, MetadataFilter filter,
                                                   final InternalFileDecryptor fileDecryptor, final boolean encryptedFooter,
                                                   final long footerOffset, final int combinedFooterLength) throws IOException {
     final BlockCipher.Decryptor footerDecryptor = (encryptedFooter? fileDecryptor.getFooterDecryptor() : null);

--- a/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/metadata/BlockMetaData.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/metadata/BlockMetaData.java
@@ -46,10 +46,17 @@ public class BlockMetaData {
 
   // Reader side (get parameters from RowGroup structure)
   public BlockMetaData(long fileOffset, long totalCompressedSize) {
-    this.startingPosition = fileOffset;
-    startingPositionSet = true;
-    this.totalCompressedSize = totalCompressedSize;
-    totalCompressedSizeSet = true;
+    // fileOffset is optional, 0 means fileOffset is absent
+    if (fileOffset > 0) {
+      this.startingPosition = fileOffset;
+      startingPositionSet = true;
+    }
+
+    // totalCompressedSize is optional, 0 means totalCompressedSize is absent
+    if (totalCompressedSize > 0) {
+      this.totalCompressedSize = totalCompressedSize;
+      totalCompressedSizeSet = true;
+    }
   }
 
 

--- a/parquet-hadoop/src/test/java/org/apache/parquet/hadoop/TestEncryption.java
+++ b/parquet-hadoop/src/test/java/org/apache/parquet/hadoop/TestEncryption.java
@@ -80,11 +80,11 @@ public class TestEncryption {
     random.nextBytes(columnKey0);
     byte[] columnKey1 = new byte[16];
     random.nextBytes(columnKey1);
-    ColumnEncryptionProperties columnProperties0 = ColumnEncryptionProperties.builder("binary_field", true)
+    ColumnEncryptionProperties columnProperties0 = ColumnEncryptionProperties.builder(ColumnPath.fromDotString("binary_field"))
         .withKey(columnKey0)
         .withKeyID("ck0")
         .build();
-    ColumnEncryptionProperties columnProperties1 = ColumnEncryptionProperties.builder("int32_field", true)
+    ColumnEncryptionProperties columnProperties1 = ColumnEncryptionProperties.builder(ColumnPath.fromDotString("int32_field"))
         .withKey(columnKey1)
         .withKeyID("ck1")
         .build();
@@ -95,7 +95,7 @@ public class TestEncryption {
     encryptionProperties = FileEncryptionProperties.builder(footerKey)
         .withFooterKeyID("fk")
         .withAADPrefix(AADPrefix)
-        .withColumnProperties(columnPropertiesMap, false)
+        .withEncryptedColumns(columnPropertiesMap)
         .build();
     StringKeyIdRetriever keyRetriever = new StringKeyIdRetriever();
     keyRetriever.putKey("fk", footerKey);
@@ -112,7 +112,7 @@ public class TestEncryption {
         .withAlgorithm(ParquetCipher.AES_GCM_CTR_V1)
         .withFooterKeyID("fk")
         .withAADPrefix(AADPrefix)
-        .withColumnProperties(columnPropertiesMap, false)
+        .withEncryptedColumns(columnPropertiesMap)
         .build();
     encryptionPropertiesList[3] = encryptionProperties;
     decryptionPropertiesList[3] = decryptionProperties; // Same decryption properties
@@ -122,7 +122,7 @@ public class TestEncryption {
         .withFooterKeyID("fk")
         .withPlaintextFooter()
         .withAADPrefix(AADPrefix)
-        .withColumnProperties(columnPropertiesMap, false)
+        .withEncryptedColumns(columnPropertiesMap)
         .build();
     encryptionPropertiesList[4] = encryptionProperties;
     decryptionPropertiesList[4] = decryptionProperties; // Same decryption properties


### PR DESCRIPTION
When I integrate the encryption of parquet-mr into presto, I found it is needed the method with signature decrypt(byte[] ciphertext, int cipherTextOffset, int cipherTextLength, byte[] AAD). 

This is because of presto rewrite parquet-mr code for reading. 

