### PR TITLE
Allow plaintext parquet file not to set file crypto metadata

### DIFF
--- a/parquet-hadoop/src/main/java/org/apache/parquet/crypto/InternalFileDecryptor.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/crypto/InternalFileDecryptor.java
@@ -210,7 +210,7 @@ public class InternalFileDecryptor {
   public InternalColumnDecryptionSetup setColumnCryptoMetadata(ColumnPath path, boolean encrypted, 
       boolean encryptedWithFooterKey, byte[] keyMetadata, short columnOrdinal) throws IOException {
     
-    if (!fileCryptoMetaDataProcessed) {
+    if (!fileCryptoMetaDataProcessed && !plaintextFile) {
       throw new IOException("Haven't parsed the file crypto metadata yet");
     }
     InternalColumnDecryptionSetup columnDecryptionSetup = columnMap.get(path);


### PR DESCRIPTION
Allow plaintext parquet file not to set file crypto metadata; Otherwise, reading plaintext parquet file will fail. Currently, this is a blocker for upgrading. 