### PR TITLE
Add information about KMS instance ID to footer metadata

### DIFF
--- a/parquet-hadoop/src/main/java/org/apache/parquet/crypto/keytools/FileKeyManager.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/crypto/keytools/FileKeyManager.java
@@ -26,6 +26,8 @@ import java.io.IOException;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.parquet.crypto.DecryptionKeyRetriever;
 import org.apache.parquet.hadoop.metadata.ColumnPath;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Management of file encryption keys, and their metadata. 
@@ -35,8 +37,13 @@ import org.apache.parquet.hadoop.metadata.ColumnPath;
  * Implementing class instance should be created per each Parquet file. The methods don't need to
  * be thread-safe.
  */
-public interface FileKeyManager {
-  
+public abstract class FileKeyManager {
+  private static final Logger LOG = LoggerFactory.getLogger(FileKeyManager.class);
+  public static final String DEFAULT_KMS_INSTANCE_ID = "DEFAULT";
+
+  protected KmsClient kmsClient;
+  protected String kmsInstanceID;
+
   /**
    * 
    * @param configuration
@@ -45,7 +52,7 @@ public interface FileKeyManager {
    * @param fileID
    * @throws IOException
    */
-  public void initialize(Configuration configuration, KmsClient kmsClient, KeyMaterialStore keyMaterialStore, String fileID) throws IOException;
+  public abstract void initialize(Configuration configuration, KmsClient kmsClient, KeyMaterialStore keyMaterialStore, String fileID) throws IOException;
   
   /**
    * File writing/encryption: Generates or fetches a column encryption key, and creates its metadata. 
@@ -56,7 +63,7 @@ public interface FileKeyManager {
    * @return
    * @throws IOException
    */
-  public KeyWithMetadata getColumnEncryptionKey(ColumnPath column, String columnKeyID) throws IOException;
+  public abstract KeyWithMetadata getColumnEncryptionKey(ColumnPath column, String columnKeyID) throws IOException;
   
   /**
    * File writing/encryption: Generates or fetches a footer encryption/signing key, and creates its metadata.
@@ -66,17 +73,98 @@ public interface FileKeyManager {
    * @return
    * @throws IOException
    */
-  public KeyWithMetadata getFooterEncryptionKey(String footerKeyID) throws IOException;
+  public abstract KeyWithMetadata getFooterEncryptionKey(String footerKeyID) throws IOException;
   
   /**
    * File reading/decryption: Returns key retrieval callback.
    * @return
    */
-  public DecryptionKeyRetriever getDecryptionKeyRetriever();
+  public abstract DecryptionKeyRetriever getDecryptionKeyRetriever();
   
   /**
    * Wipes keys in memory.
    * Flushes key material to external store (if in use).
    */
-  public void close();
+  public abstract void close();
+
+
+  /**
+   * Create and initialize a file key manager class, based on hadoop configuration.
+   * The configuration should specify the file key manager class.
+   * If kms instance ID can be fetched from the configuration or has a default value,
+   * then create and initialize a KMSClient here too.
+   * Otherwise, KMS instance ID should be fetched from parquet file metadata and only then KMS client should be created.
+   * @param configuration Hadoop configuration
+   * @return
+   * @throws IOException
+   */
+  public static FileKeyManager getKeyManager(Configuration configuration) throws IOException {
+    // Create per-file KeyManager
+    FileKeyManager keyManager = null;
+    String keyManagerClassName = configuration.getTrimmed("encryption.key.manager.class");
+    if (null == keyManagerClassName || keyManagerClassName.equals(WrappedKeyManager.class.getCanonicalName())) {
+      keyManager = new WrappedKeyManager();
+    }
+    else {
+      try {
+        keyManager = ((Class<? extends FileKeyManager>) Class.forName(keyManagerClassName)).newInstance(); // TODO
+      }
+      catch (Exception e) {
+        throw new IOException("Failed to instantiate FileKeyManager " + keyManagerClassName, e);
+      }
+    }
+    KmsClient kmsClient = keyManager.getKmsClient(configuration);
+
+    keyManager.initialize(configuration, kmsClient, null, null); //TODO add external storage?
+    return keyManager;
+  }
+
+  /**
+   * KMSClient created if KMS instance is passed in configuration or if KMS client has a default value.
+   * @param configuration
+   * @return
+   * @throws IOException
+   */
+  protected KmsClient getKmsClient(Configuration configuration) throws IOException {
+    kmsInstanceID = configuration.getTrimmed("encryption.kms.instance.id");
+    if (null == kmsInstanceID) {
+      LOG.warn("encryption.kms.instance.id not defined. Setting default KMS instance ID value.");
+      kmsInstanceID = DEFAULT_KMS_INSTANCE_ID;
+    }
+    return getKmsClient(configuration, kmsInstanceID);
+  }
+
+  /**
+   * Create and initialize a KMSClient. Called when KMS instance ID should be known.
+   * @param configuration
+   * @param kmsInstanceID
+   * @return
+   * @throws IOException
+   */
+  protected static KmsClient getKmsClient(Configuration configuration, String kmsInstanceID) throws IOException {
+    KmsClient kmsClient = instantiateKmsClient(configuration);
+    try {
+      kmsClient.initialize(configuration, kmsInstanceID);
+    } catch (IOException e) {
+      LOG.warn("Cannot create KMS client. If encryption.kms.instance.id not defined, will be expecting to use " +
+              "default KMS instance ID, if relevant, or key metadata from parquet file.");
+      return null;
+    }
+    return kmsClient;
+  }
+
+  private static KmsClient instantiateKmsClient(Configuration configuration) throws IOException {
+    String kmsClientClassName = configuration.getTrimmed("encryption.kms.client.class");
+    if (null == kmsClientClassName) {
+      throw new IOException("Undefined encryption.kms.client.class");
+    }
+
+    KmsClient kmsClient = null;
+    try {
+      kmsClient = ((Class<? extends KmsClient>) Class.forName(kmsClientClassName)).newInstance(); // TODO
+    } catch (Exception e) {
+      throw new IOException("Failed to instantiate KmsClient " + kmsClientClassName, e);
+    }
+    return kmsClient;
+  }
 }

--- a/parquet-hadoop/src/main/java/org/apache/parquet/crypto/keytools/KmsClient.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/crypto/keytools/KmsClient.java
@@ -21,21 +21,25 @@
 
 package org.apache.parquet.crypto.keytools;
 
-import java.io.IOException;
-
 import org.apache.hadoop.conf.Configuration;
 import org.apache.parquet.crypto.KeyAccessDeniedException;
 
+import java.io.IOException;
+
 
 public interface KmsClient {
-  
   /**
-   * Pass configuration with client-specific parameters
+   * Pass configuration with client-specific parameters.
+   * A KmsClient should be created when the KMS instance ID is known or if the default value is acceptable.
    * @param configuration Hadoop configuration
-   * @throws IOException 
+   * @param kmsInstanceID instance ID of the KMS managed by this KmsClient. When reading a parquet file, the KMS
+   *                      instance ID can be either specified in configuration or read from parquet file metadata.
+   *                      When writing a parquet file, the KMS instance ID has to be specified in configuration.
+   *                      Specific KmsClient implementation should decide whether the default value is acceptable here.
+   * @throws IOException
    */
-  public void initialize(Configuration configuration) throws IOException;
-  
+  public void initialize(Configuration configuration, String kmsInstanceID) throws IOException;
+
   /**
    * Supports key wrapping (envelope encryption of data key by master key) inside 
    * KMS server.
@@ -48,38 +52,40 @@ public interface KmsClient {
    * Implementation of this method is not required (can just return null) if KMS supports server side wrapping 
    * and application doesn't plan to use local (client-side) wrapping.
    * 
-   * If implemented, should throw KeyAccessDeniedException when unauthorized to get the key.
+   * IMPORTANT: if implemented, must throw KeyAccessDeniedException when unauthorized to get the key.
    * If your KMS client code throws runtime exceptions related to access/permission problems
-   * (such as Hadoop AccessControlException), catch them and throw the KeyAccessDeniedException.
+   * (such as Hadoop AccessControlException), make sure to catch them and throw the KeyAccessDeniedException.
    * 
-   * @param keyIdentifier: a string that uniquely identifies the key in KMS.
+   * @param keyIdentifier: a string that uniquely identifies the key in KMS: 
+   * ranging from a simple key ID, to e.g. a JSON with key ID, KMS instance etc.
    * @return Base64 encoded data key 
    * @throws UnsupportedOperationException
    * @throws KeyAccessDeniedException
    * @throws IOException
    */
-  public String getKeyFromServer(String keyIdentifier) 
+  public String getKeyFromServer(String keyIdentifier)
       throws UnsupportedOperationException, KeyAccessDeniedException, IOException;
-  
-  /**
+
+   /**
    * Encrypts (wraps) data key in KMS server, using the master key. 
    * The result includes everything returned by KMS (often a JSON).
    * Implementation of this method must throw an UnsupportedOperationException if KMS doesn't support server side wrapping.
    * Implementation of this method is not required (can just return null) if applications plan to store data keys in KMS (no wrapping),
    * or plan to wrap data keys locally. 
    * 
-   * If implemented, should throw KeyAccessDeniedException when unauthorized to wrap with the given master key.
+   * IMPORTANT: if implemented, must throw KeyAccessDeniedException when unauthorized to wrap with the given master key.
    * If your KMS client code throws runtime exceptions related to access/permission problems
-   * (such as Hadoop AccessControlException), catch them and throw the KeyAccessDeniedException.
+   * (such as Hadoop AccessControlException), make sure to catch them and throw the KeyAccessDeniedException.
    * 
    * @param dataKey Base64 encoded data key
-   * @param masterKeyIdentifier: a string that uniquely identifies the wrapper (master) key in KMS.
+   * @param masterKeyIdentifier: a string that uniquely identifies the wrapper (master) key in KMS: 
+   * ranging from a simple key ID, to e.g. a JSON with key ID, KMS instance etc.
    * @return
    * @throws UnsupportedOperationException
    * @throws KeyAccessDeniedException
    * @throws IOException
    */
-  public String wrapDataKeyInServer(String dataKey, String masterKeyIdentifier) 
+  public String wrapDataKeyInServer(String dataKey, String masterKeyIdentifier)
       throws UnsupportedOperationException, KeyAccessDeniedException, IOException;
   
   /**
@@ -88,17 +94,18 @@ public interface KmsClient {
    * Implementation of this method is not required (can just return null) if applications plan to store data keys in KMS (no wrapping),
    * or plan to wrap data keys locally. 
    * 
-   * If implemented, should throw KeyAccessDeniedException when unauthorized to unwrap with the given master key.
+   * IMPORTANT: if implemented, must throw KeyAccessDeniedException when unauthorized to unwrap with the given master key.
    * If your KMS client code throws runtime exceptions related to access/permission problems
-   * (such as Hadoop AccessControlException), catch them and throw the KeyAccessDeniedException.
+   * (such as Hadoop AccessControlException), make sure to catch them and throw the KeyAccessDeniedException.
    * 
    * @param wrappedDataKey includes everything returned by KMS upon wrapping.
-   * @param masterKeyIdentifier: a string that uniquely identifies the wrapper (master) key in KMS.
+   * @param masterKeyIdentifier: a string that uniquely identifies the wrapper (master) key in KMS: 
+   * ranging from a simple key ID, to e.g. a JSON with key ID, KMS instance etc.
    * @return Base64 encoded data key
    * @throws UnsupportedOperationException
    * @throws KeyAccessDeniedException
    * @throws IOException
    */
-  public String unwrapDataKeyInServer(String wrappedDataKey, String masterKeyIdentifier) 
+  public String unwrapDataKeyInServer(String wrappedDataKey, String masterKeyIdentifier)
       throws UnsupportedOperationException, KeyAccessDeniedException, IOException;
 }

--- a/parquet-hadoop/src/main/java/org/apache/parquet/crypto/keytools/RemoteKmsClient.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/crypto/keytools/RemoteKmsClient.java
@@ -1,0 +1,145 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+
+
+package org.apache.parquet.crypto.keytools;
+
+import org.apache.commons.lang.ArrayUtils;
+import org.apache.commons.lang.StringUtils;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.parquet.crypto.KeyAccessDeniedException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * An abstract class for implementation of a remote-KMS client.
+ * Both KMS instance ID and KMS URL need to be defined in order to access such a KMS.
+ * The concrete implementation should implement getKeyFromServer() and/or
+ * wrapDataKeyInServer() with unwrapDataKeyInServer() methods.
+ */
+public abstract class RemoteKmsClient implements KmsClient {
+  private static final Logger LOG = LoggerFactory.getLogger(RemoteKmsClient.class);
+
+  protected String kmsInstanceID;
+  protected String kmsURL;
+  // Example value that matches the pattern:    vault-instance-1: http://127.0.0.1:8200
+  protected Pattern kmsUrlListItemPattern = Pattern.compile("^(\\S+)\\s*:\\s*(\\w*://\\S+)$");
+
+  /**
+   *  Initialize the KMS Client with KMS instance ID and URL.
+   *  When reading a parquet file, the KMS instance ID can be either specified in configuration
+   *  or read from parquet file metadata, or default if there is a default value for this KMS type.
+   *  When writing a parquet file, the KMS instance ID has to be specified in configuration
+   *  or default if there is a default value for this KMS type.
+   *  The KMS URL has to be specified in configuration either specifically or as a mapping of KMS instance ID to KMS URL,
+   *  e.g. { "kmsInstanceID1": "kmsURL1", "kmsInstanceID2" : "kmsURL2" }, but not both.
+   * @param configuration Hadoop configuration
+   * @param kmsInstanceID instance ID of the KMS managed by this KmsClient. When reading a parquet file, the KMS
+   *                      instance ID can be either specified in configuration or read from parquet file metadata.
+   *                      When writing a parquet file, the KMS instance ID has to be specified in configuration.
+   *                      KMSClient implementation could have a default value for this.
+   * @throws IOException
+   */
+  @Override
+  public void initialize(Configuration configuration, String kmsInstanceID) throws IOException {
+    this.kmsInstanceID = kmsInstanceID;
+    setKmsURL(configuration);
+    initializeInternal(configuration);
+  }
+
+  protected abstract void initializeInternal(Configuration configuration) throws IOException;
+
+  private void setKmsURL(Configuration configuration) throws IOException {
+    final String kmsUrlProperty = configuration.getTrimmed("encryption.kms.instance.url");
+    final String[] kmsUrlList = configuration.getTrimmedStrings("encryption.kms.instance.url.list");
+    if (StringUtils.isEmpty(kmsUrlProperty) && ArrayUtils.isEmpty(kmsUrlList)) {
+      throw new IOException("KMS URL is not set.");
+    }
+    if (!StringUtils.isEmpty(kmsUrlProperty) && !ArrayUtils.isEmpty(kmsUrlList)) {
+      throw new IOException("KMS URL is ambiguous: " +
+              "it should either be set in encryption.kms.instance.url or in encryption.kms.instance.url.list");
+    }
+    if (!StringUtils.isEmpty(kmsUrlProperty)) {
+      kmsURL = kmsUrlProperty;
+    } else {
+      if (StringUtils.isEmpty(kmsInstanceID) ) {
+        throw new IOException("Missing kms instance id value. Cannot find a matching KMS URL mapping.");
+      }
+      Map<String, String> kmsUrlMap = new HashMap<String, String>(kmsUrlList.length);
+      int nKeys = kmsUrlList.length;
+      for (int i=0; i < nKeys; i++) {
+        Matcher m = kmsUrlListItemPattern.matcher(kmsUrlList[i]);
+        if (!m.matches() || (m.groupCount() != 2)) {
+          throw new IOException(String.format("String %s doesn't match pattern %s for KMS URL mapping",
+                  kmsUrlList[i], kmsUrlListItemPattern.toString()));
+        }
+        String instanceID = m.group(1);
+        String kmsURL = m.group(2);
+        //TODO check parts
+        kmsUrlMap.put(instanceID, kmsURL);
+      }
+      kmsURL = kmsUrlMap.get(kmsInstanceID);
+      if (StringUtils.isEmpty(kmsURL) ) {
+        throw new IOException(String.format("Missing KMS URL for kms instance ID [%s] in KMS URL mapping",
+                kmsInstanceID));
+      }
+    }
+  }
+
+
+  @Override
+  public abstract boolean supportsServerSideWrapping();
+
+  /**
+   * This method should be implemented by the concrete RemoteKmsClient implementation,
+   * otherwise it throws an UnsupportedOperationException.
+   */
+  @Override
+  public String getKeyFromServer(String keyIdentifier)
+      throws UnsupportedOperationException, KeyAccessDeniedException, IOException {
+    throw new UnsupportedOperationException();
+  }
+
+  /**
+   * This method should be implemented by the concrete RemoteKmsClient implementation,
+   * otherwise it throws an UnsupportedOperationException.
+   */
+  @Override
+  public String wrapDataKeyInServer(String dataKey, String masterKeyIdentifier)
+      throws UnsupportedOperationException, KeyAccessDeniedException, IOException {
+    throw new UnsupportedOperationException();
+  }
+
+  /**
+   * This method should be implemented by the concrete RemoteKmsClient implementation,
+   * otherwise it throws an UnsupportedOperationException.
+   */
+  @Override
+  public String unwrapDataKeyInServer(String wrappedDataKey, String masterKeyIdentifier)
+      throws UnsupportedOperationException, KeyAccessDeniedException, IOException {
+    throw new UnsupportedOperationException();
+  }
+}


### PR DESCRIPTION
Then on file reading, KMS instance ID doesn't have to be provided in properties, but can be read from the metadata.

Add RemoteKmsClient abstract class to assist implementing KMSClients for remote KMSs, that are accessed using URL.
KMS URL should be specified in properties either directly or in a list. KMS instance ID is either default, or should be specified in properties or read from footer metadata.
Make DoubleWrappedKeyManager inherit from WrappedKeyManager and make FileKeyManager an abstract class. Add a static factory method to FileKeyManager to initialize an appropriate KSMClient and Key manager.
