### PR TITLE
Change caches of EnvelopeKeyManager and EnvelopeKeyRetriever to be per token.

### DIFF
--- a/parquet-hadoop/src/main/java/org/apache/parquet/crypto/keytools/EnvelopeKeyManager.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/crypto/keytools/EnvelopeKeyManager.java
@@ -117,18 +117,10 @@ public class EnvelopeKeyManager {
     this.cacheEntryLifetime = hadoopConfiguration.getLong(CACHE_ENTRY_LIFETIME_PROPERTY_NAME, DEFAULT_CACHE_ENTRY_LIFETIME);
     invalidateCachesForExpiredTokens();
 
-    String kmsInstanceID = hadoopConfiguration.getTrimmed(RemoteKmsClient.KMS_INSTANCE_ID_PROPERTY_NAME);
-    if (StringUtils.isEmpty(kmsInstanceID)) {
-      kmsInstanceID = DEFAULT_KMS_INSTANCE_ID;
-    }
-    this.kmsInstanceID = kmsInstanceID;
+    this.kmsInstanceID = hadoopConfiguration.getTrimmed(RemoteKmsClient.KMS_INSTANCE_ID_PROPERTY_NAME, DEFAULT_KMS_INSTANCE_ID);
     this.kmsClient = getKmsClient(configuration, kmsInstanceID);
 
-    String kmsInstanceURLForParquetWrite = hadoopConfiguration.getTrimmed(RemoteKmsClient.KMS_INSTANCE_URL_PROPERTY_NAME);
-    if (StringUtils.isEmpty(kmsInstanceURLForParquetWrite)) {
-      kmsInstanceURLForParquetWrite = DEFAULT_KMS_INSTANCE_URL;
-    }
-    this.kmsInstanceURLForParquetWrite = kmsInstanceURLForParquetWrite;
+    this.kmsInstanceURLForParquetWrite = hadoopConfiguration.getTrimmed(RemoteKmsClient.KMS_INSTANCE_URL_PROPERTY_NAME, DEFAULT_KMS_INSTANCE_URL);
 
     this.keyMaterialStore = keyMaterialStore;
     random = new SecureRandom();

--- a/parquet-hadoop/src/main/java/org/apache/parquet/crypto/keytools/EnvelopeKeyRetriever.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/crypto/keytools/EnvelopeKeyRetriever.java
@@ -24,14 +24,14 @@ import java.io.IOException;
 import java.io.StringReader;
 import java.nio.charset.StandardCharsets;
 import java.util.Base64;
-import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
 
 import org.apache.commons.lang.ArrayUtils;
 import org.apache.commons.lang.StringUtils;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.parquet.crypto.DecryptionKeyRetriever;
-import org.apache.parquet.crypto.KeyAccessDeniedException;
 import org.apache.parquet.crypto.ParquetCryptoRuntimeException;
 import org.apache.parquet.crypto.keytools.KeyToolUtilities.KeyWithMasterID;
 import org.codehaus.jackson.map.ObjectMapper;
@@ -42,22 +42,46 @@ import org.slf4j.LoggerFactory;
 public class EnvelopeKeyRetriever implements DecryptionKeyRetriever {
   private static final Logger LOG = LoggerFactory.getLogger(EnvelopeKeyRetriever.class);
 
-  private static final Map<String,byte[]> readSessionKEKMap = new HashMap<String, byte[]>();
+  private static final ConcurrentMap<String, ExpiringCacheEntry<ConcurrentMap<String,byte[]>>> readKEKMapPerToken
+    = new ConcurrentHashMap<>();
+  private static final Object readKEKCacheLock = new Object();
+  private static volatile Long lastCacheCleanupTimestamp = System.currentTimeMillis() + 60l * 1000; // grace period of 1 minute
+  private final String accessToken;
+
+  private ConcurrentMap<String,byte[]> readSessionKEKMap;
+  private final long cacheEntryLifetime;
   private static final ObjectMapper objectMapper = new ObjectMapper();
 
   private KmsClient kmsClient;
   private final FileKeyMaterialStore keyMaterialStore;
   private final Configuration hadoopConfiguration;
 
-  EnvelopeKeyRetriever(KmsClient kmsClient, Configuration hadoopConfiguration,
+  public EnvelopeKeyRetriever(KmsClient kmsClient, Configuration hadoopConfiguration,
       FileKeyMaterialStore keyStore) {
     this.kmsClient = kmsClient;
     this.hadoopConfiguration = hadoopConfiguration;
     this.keyMaterialStore = keyStore;
+
+    this.accessToken = EnvelopeKeyManager.getAccessTokenOrDefault(hadoopConfiguration);
+
+    this.cacheEntryLifetime = hadoopConfiguration.getLong(EnvelopeKeyManager.CACHE_ENTRY_LIFETIME_PROPERTY_NAME,
+      EnvelopeKeyManager.DEFAULT_CACHE_ENTRY_LIFETIME);
+    invalidateCachesForExpiredTokens();
+    ExpiringCacheEntry<ConcurrentMap<String, byte[]>> readKEKCacheEntry = readKEKMapPerToken.get(accessToken);
+    if ((null == readKEKCacheEntry) || (readKEKCacheEntry.isExpired())) {
+      synchronized (readKEKCacheLock) {
+        if ((null == readKEKCacheEntry) || (readKEKCacheEntry.isExpired())) {
+          LOG.debug("CACHE --- create read-KEK cache for token: " + accessToken.substring(accessToken.length() - 5));
+          readKEKCacheEntry = new ExpiringCacheEntry<>(new ConcurrentHashMap<String,byte[]>(), cacheEntryLifetime);
+          readKEKMapPerToken.put(accessToken, readKEKCacheEntry);
+        }
+      }
+    }
+    this.readSessionKEKMap = readKEKCacheEntry.getCachedItem();
   }
 
   @Override
-  public byte[] getKey(byte[] keyMetaData) throws ParquetCryptoRuntimeException, KeyAccessDeniedException {
+  public byte[] getKey(byte[] keyMetaData) {
     String keyMaterial;
     if (null != keyMaterialStore) {
       String keyReferenceMetadata = new String(keyMetaData, StandardCharsets.UTF_8);
@@ -107,28 +131,19 @@ public class EnvelopeKeyRetriever implements DecryptionKeyRetriever {
     
     byte[] dataKey;
     if (!doubleWrapping) {
+      try {
       dataKey = kmsClient.unwrapDataKey(encodedWrappedDatakey, masterKeyID);
+      } catch (IOException e) {
+        throw new ParquetCryptoRuntimeException(e);
+      }
     } else {
       // Get KEK
       String encodedKEK_ID = keyMaterialJson.get(EnvelopeKeyManager.KEK_ID_FIELD);
-      byte[] kekBytes = readSessionKEKMap.get(encodedKEK_ID);
-
-      if (null == kekBytes) {
-        synchronized (readSessionKEKMap) {
-          kekBytes = readSessionKEKMap.get(encodedKEK_ID);
-          if (null == kekBytes) {
-            String encodedWrappedKEK = keyMaterialJson.get(EnvelopeKeyManager.WRAPPED_KEK_FIELD);
-
-            kekBytes = kmsClient.unwrapDataKey(encodedWrappedKEK, masterKeyID); // TODO nested sync. Break.
-
-            if (null == kekBytes) {
-              throw new ParquetCryptoRuntimeException("Null KEK, after unwrapping in KMS with master key " + masterKeyID);
-            }
-
-            readSessionKEKMap.put(encodedKEK_ID, kekBytes);
-          }
-        } // sync readSessionKEKMap
-      }
+      final Map<String, String> keyMaterialJsonFinal = keyMaterialJson;
+      byte[] kekBytes = readSessionKEKMap.computeIfAbsent(encodedKEK_ID, (k) -> {
+        LOG.debug("CACHE --- get kek " + masterKeyID + " and add to read-KEK cache");
+        return unwrapKek(keyMaterialJsonFinal, masterKeyID);
+      });
 
       // Decrypt the data key
       byte[]  AAD = Base64.getDecoder().decode(encodedKEK_ID);
@@ -136,6 +151,20 @@ public class EnvelopeKeyRetriever implements DecryptionKeyRetriever {
     }
 
     return new KeyWithMasterID(dataKey, masterKeyID);
+  }
+
+  private byte[] unwrapKek(Map<String, String> keyMaterialJson, String masterKeyID) {
+    byte[] kekBytes;
+    String encodedWrappedKEK = keyMaterialJson.get(EnvelopeKeyManager.WRAPPED_KEK_FIELD);
+    try {
+      kekBytes = kmsClient.unwrapDataKey(encodedWrappedKEK, masterKeyID);
+    } catch (IOException e) {
+      throw new ParquetCryptoRuntimeException(e);
+    }
+    if (null == kekBytes) {
+      throw new ParquetCryptoRuntimeException("Null KEK, after unwrapping in KMS with master key " + masterKeyID);
+    }
+    return kekBytes;
   }
 
   /**
@@ -184,11 +213,35 @@ public class EnvelopeKeyRetriever implements DecryptionKeyRetriever {
     }
 
     String storageLocation = keyMetadataJson.get(EnvelopeKeyManager.KEY_METADATA_STORAGE_FIELD);
-    if (!targetStorageLocation.equals(storageLocation)) {
-      throw new ParquetCryptoRuntimeException("Wrong key material storage location " + storageLocation + 
-          " vs " + targetStorageLocation); // TODO
+    LOG.debug("Key material storage location " + storageLocation + " vs " + targetStorageLocation);
+    return keyMetadataJson.get(EnvelopeKeyManager.KEY_REFERENCE_FIELD);
     }
 
-    return keyMetadataJson.get(EnvelopeKeyManager.KEY_REFERENCE_FIELD);
+  /**
+   * Flush any caches that are tied to the specified accessToken
+   * @param accessToken
+   */
+  public static void invalidateCachesForToken(String accessToken) {
+    synchronized (readKEKCacheLock) {
+      readKEKMapPerToken.remove(accessToken);
+    }
+  }
+
+  private void invalidateCachesForExpiredTokens() {
+    long now = System.currentTimeMillis();
+    if (now > lastCacheCleanupTimestamp + this.cacheEntryLifetime) {
+      synchronized (readKEKCacheLock) {
+        if (now > lastCacheCleanupTimestamp + this.cacheEntryLifetime) {
+          EnvelopeKeyManager.removeExpiredEntriesFromCache(readKEKMapPerToken);
+          lastCacheCleanupTimestamp = now;
+        }
+      }
+    }
+  }
+
+  static void invalidateCachesForAllTokens() {
+    synchronized (readKEKCacheLock) {
+      readKEKMapPerToken.clear();
+    }
   }
 }

--- a/parquet-hadoop/src/main/java/org/apache/parquet/crypto/keytools/EnvelopeKeyRetriever.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/crypto/keytools/EnvelopeKeyRetriever.java
@@ -42,12 +42,14 @@ import org.slf4j.LoggerFactory;
 public class EnvelopeKeyRetriever implements DecryptionKeyRetriever {
   private static final Logger LOG = LoggerFactory.getLogger(EnvelopeKeyRetriever.class);
 
+  // For every token a map of KEK_ID to KEK bytes
   private static final ConcurrentMap<String, ExpiringCacheEntry<ConcurrentMap<String,byte[]>>> readKEKMapPerToken
     = new ConcurrentHashMap<>();
   private static final Object readKEKCacheLock = new Object();
   private static volatile Long lastCacheCleanupTimestamp = System.currentTimeMillis() + 60l * 1000; // grace period of 1 minute
   private final String accessToken;
 
+  // A map of KEK_ID to KEK bytes for the current token
   private ConcurrentMap<String,byte[]> readSessionKEKMap;
   private final long cacheEntryLifetime;
   private static final ObjectMapper objectMapper = new ObjectMapper();
@@ -109,16 +111,16 @@ public class EnvelopeKeyRetriever implements DecryptionKeyRetriever {
 
     boolean doubleWrapping;
     String wrapMethod = keyMaterialJson.get(EnvelopeKeyManager.WRAPPING_METHOD_FIELD); // TODO static import
-    if (wrapMethod.equals(EnvelopeKeyManager.single_wrapping_method)) {
+    if (wrapMethod.equals(EnvelopeKeyManager.SINGLE_WRAPPING_METHOD)) {
       doubleWrapping = false;
-    } else if (wrapMethod.equals(EnvelopeKeyManager.double_wrapping_method)) {
+    } else if (wrapMethod.equals(EnvelopeKeyManager.DOUBLE_WRAPPING_METHOD)) {
       doubleWrapping = true;
     } else {
       throw new ParquetCryptoRuntimeException("Wrong wrapping method " + wrapMethod);
     }
 
     String wrapMethodVersion = keyMaterialJson.get(EnvelopeKeyManager.WRAPPING_METHOD_VERSION_FIELD);
-    if (!EnvelopeKeyManager.wrapping_method_version.equals(wrapMethodVersion)) {
+    if (!EnvelopeKeyManager.WRAPPING_METHOD_VERSION.equals(wrapMethodVersion)) {
       throw new ParquetCryptoRuntimeException("Wrong wrapping method version " + wrapMethodVersion); // TODO
     }
 

--- a/parquet-hadoop/src/main/java/org/apache/parquet/crypto/keytools/ExpiringCacheEntry.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/crypto/keytools/ExpiringCacheEntry.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.parquet.crypto.keytools;
+
+/**
+ * Immutable class for cache entries that have expiration timestamp
+ */
+public class ExpiringCacheEntry<E>  {
+  private final long expirationTimestamp;
+  private final E cachedItem;
+
+  public ExpiringCacheEntry(E cachedItem, long expirationIntervalMillis) {
+    this.expirationTimestamp = System.currentTimeMillis() + expirationIntervalMillis;
+    this.cachedItem = cachedItem;
+  }
+
+  /**
+   * Cache entry is expired
+   *
+   * @return
+   */
+  public boolean isExpired() {
+    final long now = System.currentTimeMillis();
+    return (now > expirationTimestamp);
+  }
+
+  public E getCachedItem() {
+    return cachedItem;
+  }
+}

--- a/parquet-hadoop/src/main/java/org/apache/parquet/crypto/keytools/KeyRotationTool.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/crypto/keytools/KeyRotationTool.java
@@ -26,20 +26,14 @@ import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
+import org.apache.parquet.crypto.EncryptionPropertiesFactory;
 import org.apache.parquet.crypto.KeyAccessDeniedException;
 import org.apache.parquet.crypto.ParquetCryptoRuntimeException;
 import org.apache.parquet.hadoop.util.HiddenFileFilter;
 
 public class KeyRotationTool  {
 
-  private Configuration hadoopConfig;
-
-  public KeyRotationTool(Configuration hadoopConfig) {
-    this.hadoopConfig = hadoopConfig;
-  }
-
-
-  public void rotateMasterKeys(String folderPath) throws IOException, ParquetCryptoRuntimeException, KeyAccessDeniedException {
+  public static void rotateMasterKeys(String folderPath, Configuration hadoopConfig) throws IOException, ParquetCryptoRuntimeException, KeyAccessDeniedException {
 
     Path parentPath = new Path(folderPath);
 

--- a/parquet-hadoop/src/main/java/org/apache/parquet/crypto/keytools/KmsClient.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/crypto/keytools/KmsClient.java
@@ -39,7 +39,7 @@ public interface KmsClient {
    *                      Specific KmsClient implementation should decide whether the default value is acceptable here.
    * @throws IOException
    */
-  public void initialize(Configuration configuration, String kmsInstanceID) throws ParquetCryptoRuntimeException;
+  public void initialize(Configuration configuration, String kmsInstanceID) throws IOException, KeyAccessDeniedException, UnsupportedOperationException;
 
   /**
    * Encrypts (wraps) data key in KMS server, using the master key. 
@@ -58,7 +58,7 @@ public interface KmsClient {
    * @throws KeyAccessDeniedException
    */
   public String wrapDataKey(byte[] dataKey, String masterKeyIdentifier)
-      throws ParquetCryptoRuntimeException, KeyAccessDeniedException;
+      throws IOException, KeyAccessDeniedException, UnsupportedOperationException;
 
   /**
    * Decrypts (unwraps) data key in KMS server, using the master key. 
@@ -77,5 +77,5 @@ public interface KmsClient {
    * @throws KeyAccessDeniedException
    */
   public byte[] unwrapDataKey(String wrappedDataKey, String masterKeyIdentifier)
-      throws ParquetCryptoRuntimeException, KeyAccessDeniedException;
+      throws IOException, KeyAccessDeniedException, UnsupportedOperationException;
 }

--- a/parquet-hadoop/src/main/java/org/apache/parquet/crypto/keytools/RemoteKmsClient.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/crypto/keytools/RemoteKmsClient.java
@@ -172,12 +172,11 @@ public abstract class RemoteKmsClient implements KmsClient {
 
   private byte[] getKeyFromCacheOrServer(String keyIdentifier) throws IOException {
     invalidateExpiredKeyCacheEntries();
-    ExpiringCacheEntry<byte[]> keyCacheEntry = null;
-    ExpiringCacheEntry<byte[]> expiringCacheEntry = masterKeyCache.get(keyIdentifier);
-    if ((null == expiringCacheEntry) || expiringCacheEntry.isExpired()) {
+    ExpiringCacheEntry<byte[]> keyCacheEntry = masterKeyCache.get(keyIdentifier);
+    if ((null == keyCacheEntry) || keyCacheEntry.isExpired()) {
       synchronized (cacheLock) {
-        expiringCacheEntry = masterKeyCache.get(keyIdentifier);
-        if ((null == expiringCacheEntry) || expiringCacheEntry.isExpired()) {
+        keyCacheEntry = masterKeyCache.get(keyIdentifier);
+        if ((null == keyCacheEntry) || keyCacheEntry.isExpired()) {
           byte[] key = getKeyFromServer(keyIdentifier);
           keyCacheEntry = new ExpiringCacheEntry<>(key, cacheEntryLifetime);
           masterKeyCache.put(keyIdentifier, keyCacheEntry);

--- a/parquet-hadoop/src/main/java/org/apache/parquet/crypto/keytools/RemoteKmsClient.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/crypto/keytools/RemoteKmsClient.java
@@ -26,11 +26,14 @@ import org.apache.commons.lang.StringUtils;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.parquet.crypto.KeyAccessDeniedException;
 import org.apache.parquet.crypto.ParquetCryptoRuntimeException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.Map;
+import java.nio.charset.StandardCharsets;
+import java.util.*;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -41,22 +44,30 @@ import java.util.regex.Pattern;
  * wrapDataKeyInServer() with unwrapDataKeyInServer() methods.
  */
 public abstract class RemoteKmsClient implements KmsClient {
-  public static final String KEY_ACCESS_TOKEN_PROPERTY_NAME = "encryption.key.access.token";
+  private static final Logger LOG = LoggerFactory.getLogger(RemoteKmsClient.class);
+
   public static final String KMS_INSTANCE_ID_PROPERTY_NAME = "encryption.kms.instance.id";
   public static final String KMS_INSTANCE_URL_PROPERTY_NAME = "encryption.kms.instance.url";
   public static final String KMS_INSTANCE_URL_LIST_PROPERTY_NAME = "encryption.kms.instance.url.list";
+  public static final String WRAP_LOCALLY_PROPERTY_NAME = "encryption.wrap.locally";
+  public static final String CACHE_ENTRY_LIFETIME_PROPERTY_NAME = "encryption.cache.entry.lifetime";
   
-  private static final long KEY_CACHE_EXPIRATION_TIME = 10 * 60 * 1000; // 10 minutes
+  private static final long DEFAULT_CACHE_ENTRY_LIFETIME = 10 * 60 * 1000; // 10 minutes
 
   protected String kmsInstanceID;
   protected String kmsURL;
   // Example value that matches the pattern:    vault-instance-1: http://127.0.0.1:8200
   protected Pattern kmsUrlListItemPattern = Pattern.compile("^(\\S+)\\s*:\\s*(\\w*://\\S+)$");
+  protected Boolean isWrapLocally;
 
-  // Key cache per KmsClient instance, since it is shared by multiple threads with the same
+  // MasterKey cache: key material per master key ID, concurrent since it can be shared by multiple threads with the same
   // KMS instance id and access token
   private final int INITIAL_KEY_CACHE_SIZE = 10;
-  private final Map<String, SelfDestructiveKeyCacheEntry> keyCache = new HashMap<String, SelfDestructiveKeyCacheEntry>(INITIAL_KEY_CACHE_SIZE);
+  private final ConcurrentMap<String, ExpiringCacheEntry<byte[]>> masterKeyCache =
+    new ConcurrentHashMap<>(INITIAL_KEY_CACHE_SIZE);
+  private final Object cacheLock = new Object();
+  private long cacheEntryLifetime;
+  private volatile Long lastCacheCleanupTimestamp = System.currentTimeMillis() + 60l * 1000; // grace period of 1 minute
 
   /**
    *  Initialize the KMS Client with KMS instance ID and URL.
@@ -81,13 +92,37 @@ public abstract class RemoteKmsClient implements KmsClient {
    * @throws IOException
    */
   @Override
-  public void initialize(Configuration configuration, String kmsInstanceID) throws ParquetCryptoRuntimeException {
+  public void initialize(Configuration configuration, String kmsInstanceID) throws IOException, KeyAccessDeniedException, UnsupportedOperationException {
     this.kmsInstanceID = kmsInstanceID;
     setKmsURL(configuration);
+    this.isWrapLocally = configuration.getBoolean(WRAP_LOCALLY_PROPERTY_NAME, false);
+    this.cacheEntryLifetime = configuration.getLong(CACHE_ENTRY_LIFETIME_PROPERTY_NAME, DEFAULT_CACHE_ENTRY_LIFETIME);
     initializeInternal(configuration);
   }
 
-  protected abstract void initializeInternal(Configuration configuration) throws ParquetCryptoRuntimeException;
+  @Override
+  public String wrapDataKey(byte[] dataKey, String masterKeyIdentifier) throws IOException, KeyAccessDeniedException, UnsupportedOperationException {
+    if (isWrapLocally) {
+      byte[] masterKey = getKeyFromCacheOrServer(masterKeyIdentifier);
+      byte[] AAD = masterKeyIdentifier.getBytes(StandardCharsets.UTF_8);
+      return KeyToolUtilities.wrapKeyLocally(dataKey, masterKey, AAD);
+    } else {
+      return wrapDataKeyInServer(dataKey, masterKeyIdentifier);
+    }
+  }
+
+  @Override
+  public byte[] unwrapDataKey(String wrappedKey, String masterKeyIdentifier) throws IOException, KeyAccessDeniedException, UnsupportedOperationException {
+      if (isWrapLocally) {
+        byte[] masterKey = getKeyFromCacheOrServer(masterKeyIdentifier);
+        byte[] AAD = masterKeyIdentifier.getBytes(StandardCharsets.UTF_8);
+        return KeyToolUtilities.unwrapKeyLocally(wrappedKey, masterKey, AAD);
+      } else {
+        return unwrapDataKeyInServer(wrappedKey, masterKeyIdentifier);
+      }
+  }
+
+  protected abstract void initializeInternal(Configuration configuration) throws IOException, KeyAccessDeniedException, UnsupportedOperationException;
 
   private void setKmsURL(Configuration configuration) throws ParquetCryptoRuntimeException {
     final String kmsUrlProperty = configuration.getTrimmed(KMS_INSTANCE_URL_PROPERTY_NAME);
@@ -117,8 +152,7 @@ public abstract class RemoteKmsClient implements KmsClient {
         String kmsURL = m.group(2);
         //TODO check parts
         kmsUrlMap.put(instanceID, kmsURL);
-      }
-      kmsURL = kmsUrlMap.get(kmsInstanceID);
+      }      kmsURL = kmsUrlMap.get(kmsInstanceID);
       if (StringUtils.isEmpty(kmsURL) ) {
         throw new ParquetCryptoRuntimeException(String.format("Missing KMS URL for kms instance ID [%s] in KMS URL mapping",
             kmsInstanceID));
@@ -137,66 +171,52 @@ public abstract class RemoteKmsClient implements KmsClient {
    * @throws IOException
    */
 
-  protected byte[] getKeyFromServer(String keyIdentifier)
-      throws KeyAccessDeniedException, IOException {
-    byte[] keyCopy;
-    synchronized (keyCache) {
-      SelfDestructiveKeyCacheEntry keyCacheEntry = keyCache.get(keyIdentifier);
-      byte[] key;
-      if ((null == keyCacheEntry) || (null == (key = keyCacheEntry.getEncryptionKey())) || !keyCacheEntry.isValid()) {
-        // We try to minimize calls to this expensive operation using the cache
-        key = getKeyFromServerRemoteCall(keyIdentifier);
-        final long expirationTimestamp = System.currentTimeMillis() + KEY_CACHE_EXPIRATION_TIME;
-        // Add a new cache entry or overwrite an expired one
-        keyCache.put(keyIdentifier, new SelfDestructiveKeyCacheEntry(key, expirationTimestamp));
+  private byte[] getKeyFromCacheOrServer(String keyIdentifier) throws IOException {
+    invalidateExpiredKeyCacheEntries();
+    ExpiringCacheEntry<byte[]> keyCacheEntry = null;
+    ExpiringCacheEntry<byte[]> expiringCacheEntry = masterKeyCache.get(keyIdentifier);
+    if ((null == expiringCacheEntry) || expiringCacheEntry.isExpired()) {
+      synchronized (cacheLock) {
+        expiringCacheEntry = masterKeyCache.get(keyIdentifier);
+        if ((null == expiringCacheEntry) || expiringCacheEntry.isExpired()) {
+          byte[] key = getKeyFromServer(keyIdentifier);
+          keyCacheEntry = new ExpiringCacheEntry<>(key, cacheEntryLifetime);
+          masterKeyCache.put(keyIdentifier, keyCacheEntry);
       }
-      keyCopy = Arrays.copyOf(key, key.length);
     }
-    return keyCopy;
+  }
+    return keyCacheEntry.getCachedItem();
   }
 
-  /**
+  private void invalidateExpiredKeyCacheEntries() {
+    long now = System.currentTimeMillis();
+    if (now > lastCacheCleanupTimestamp + this.cacheEntryLifetime) {
+      synchronized (cacheLock) {
+        if (now > lastCacheCleanupTimestamp + this.cacheEntryLifetime) {
+          Set<Map.Entry<String, ExpiringCacheEntry<byte[]>>> cacheEntries = masterKeyCache.entrySet();
+          List<String> expiredKeys = new ArrayList<>(cacheEntries.size());
+          for (Map.Entry<String, ExpiringCacheEntry<byte[]>> cacheEntry : cacheEntries) {
+            if (cacheEntry.getValue().isExpired()) {
+              expiredKeys.add(cacheEntry.getKey());
+            }
+          }
+          LOG.debug("CACHE --- Removing " + expiredKeys.size() + " expired key entries from cache");
+          masterKeyCache.keySet().removeAll(expiredKeys);
+          lastCacheCleanupTimestamp = now;
+        }
+    }
+      }
+    }
+
+    /**
    * Get a standard key from server - call the remote server, without using the key cache.
    * This method should be implemented by the concrete RemoteKmsClient implementation,
-   * otherwise it throws an UnsupportedOperationException.
-   */
-  protected byte[] getKeyFromServerRemoteCall(String keyIdentifier) throws IOException, KeyAccessDeniedException, UnsupportedOperationException {
-    throw new UnsupportedOperationException();
-  }
-
-  /**
-   * Self destructive key cache entry - if getKey is called on an expired entry, 
-   * then the key reference is automatically removed
-   */
-  // TODO needed? Now its a simple reference removal
-  private static class SelfDestructiveKeyCacheEntry {
-
-    private byte[] encryptionKey;
-    private final long expirationTimestamp;
-
-    public SelfDestructiveKeyCacheEntry(byte[] encryptionKey, long expirationTimestamp) {
-      this.encryptionKey = encryptionKey;
-      this.expirationTimestamp = expirationTimestamp;
-    }
-
-    /**
-     * Returns the key, if the cache entry is still valid (not expired).
-     * @return
+   * or otherwise  throw UnsupportedOperationException.
      */
-    public byte[] getEncryptionKey() {
-      if (!isValid()) {
-        encryptionKey = null;
-      }
-      return encryptionKey;
-    }
+  protected abstract byte[] getKeyFromServer(String keyIdentifier) throws IOException, KeyAccessDeniedException, UnsupportedOperationException;
 
-    /**
-     * Returns true if the cache entry is not expired yet.
-     * @return
-     */
-    public boolean isValid() {
-      final long now = System.currentTimeMillis();
-      return (now < expirationTimestamp);
-    }
-  }
+  protected abstract String wrapDataKeyInServer(byte[] dataKey, String masterKeyIdentifier) throws IOException, KeyAccessDeniedException, UnsupportedOperationException;
+
+  protected abstract byte[] unwrapDataKeyInServer(String wrappedKey, String masterKeyIdentifier) throws IOException, KeyAccessDeniedException, UnsupportedOperationException;
+
 }

--- a/parquet-hadoop/src/main/java/org/apache/parquet/crypto/keytools/RemoteKmsClient.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/crypto/keytools/RemoteKmsClient.java
@@ -25,7 +25,6 @@ import org.apache.commons.lang.ArrayUtils;
 import org.apache.commons.lang.StringUtils;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.parquet.crypto.KeyAccessDeniedException;
-import org.apache.parquet.crypto.ParquetCryptoRuntimeException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -124,28 +123,28 @@ public abstract class RemoteKmsClient implements KmsClient {
 
   protected abstract void initializeInternal(Configuration configuration) throws IOException, KeyAccessDeniedException, UnsupportedOperationException;
 
-  private void setKmsURL(Configuration configuration) throws ParquetCryptoRuntimeException {
+  private void setKmsURL(Configuration configuration) throws IOException {
     final String kmsUrlProperty = configuration.getTrimmed(KMS_INSTANCE_URL_PROPERTY_NAME);
     final String[] kmsUrlList = configuration.getTrimmedStrings(KMS_INSTANCE_URL_LIST_PROPERTY_NAME);
     if (StringUtils.isEmpty(kmsUrlProperty) && ArrayUtils.isEmpty(kmsUrlList) || "DEFAULT".equals(kmsUrlProperty)) {
-      throw new ParquetCryptoRuntimeException("KMS URL is not set.");
+      throw new IOException("KMS URL is not set.");
     }
     if (!StringUtils.isEmpty(kmsUrlProperty) && !ArrayUtils.isEmpty(kmsUrlList)) {
-      throw new ParquetCryptoRuntimeException("KMS URL is ambiguous: " +
+      throw new IOException("KMS URL is ambiguous: " +
           "it should either be set in encryption.kms.instance.url or in encryption.kms.instance.url.list"); // TODO use constants
     }
     if (!StringUtils.isEmpty(kmsUrlProperty)) {
       kmsURL = kmsUrlProperty;
     } else {
       if (StringUtils.isEmpty(kmsInstanceID) ) {
-        throw new ParquetCryptoRuntimeException("Missing kms instance id value. Cannot find a matching KMS URL mapping.");
+        throw new IOException("Missing kms instance id value. Cannot find a matching KMS URL mapping.");
       }
       Map<String, String> kmsUrlMap = new HashMap<String, String>(kmsUrlList.length);
       int nKeys = kmsUrlList.length;
       for (int i=0; i < nKeys; i++) {
         Matcher m = kmsUrlListItemPattern.matcher(kmsUrlList[i]);
         if (!m.matches() || (m.groupCount() != 2)) {
-          throw new ParquetCryptoRuntimeException(String.format("String %s doesn't match pattern %s for KMS URL mapping",
+          throw new IOException(String.format("String %s doesn't match pattern %s for KMS URL mapping",
               kmsUrlList[i], kmsUrlListItemPattern.toString()));
         }
         String instanceID = m.group(1);
@@ -154,7 +153,7 @@ public abstract class RemoteKmsClient implements KmsClient {
         kmsUrlMap.put(instanceID, kmsURL);
       }      kmsURL = kmsUrlMap.get(kmsInstanceID);
       if (StringUtils.isEmpty(kmsURL) ) {
-        throw new ParquetCryptoRuntimeException(String.format("Missing KMS URL for kms instance ID [%s] in KMS URL mapping",
+        throw new IOException(String.format("Missing KMS URL for kms instance ID [%s] in KMS URL mapping",
             kmsInstanceID));
       }
     }

--- a/parquet-hadoop/src/main/java/org/apache/parquet/crypto/keytools/samples/VaultClient.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/crypto/keytools/samples/VaultClient.java
@@ -1,0 +1,167 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.parquet.crypto.keytools.samples;
+
+import okhttp3.MediaType;
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.RequestBody;
+import okhttp3.Response;
+import org.apache.commons.lang.StringUtils;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.parquet.crypto.KeyAccessDeniedException;
+import org.apache.parquet.crypto.keytools.EnvelopeKeyManager;
+import org.apache.parquet.crypto.keytools.RemoteKmsClient;
+import org.codehaus.jackson.JsonNode;
+import org.codehaus.jackson.map.ObjectMapper;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.util.Base64;
+import java.util.HashMap;
+import java.util.Map;
+
+public class VaultClient extends RemoteKmsClient {
+  private static final Logger LOG = LoggerFactory.getLogger(VaultClient.class);
+  private static final MediaType JSON_MEDIA_TYPE = MediaType.get("application/json; charset=utf-8");
+  private static final String DEFAULT_TRANSIT_ENGINE = "/v1/transit/";
+  private static final String transitWrapEndpoint = "encrypt/";
+  private static final String transitUnwrapEndpoint = "decrypt/";
+  private static final String DEFAULT_KV_ENGINE = "/v1/secret/data/keys";
+  private static final String tokenHeader="X-Vault-Token";
+  private static final ObjectMapper objectMapper = new ObjectMapper();
+
+  private String transitEngine = DEFAULT_TRANSIT_ENGINE;
+  private String getKeyEndpoint = DEFAULT_KV_ENGINE;
+  private OkHttpClient httpClient = new OkHttpClient();
+
+  private String vaultToken;
+
+  @Override
+  protected void initializeInternal(Configuration conf) throws IOException {
+    vaultToken = conf.getTrimmed(EnvelopeKeyManager.KEY_ACCESS_TOKEN_PROPERTY_NAME);
+    if (StringUtils.isEmpty(vaultToken)) {
+      throw new IOException("Missing token");
+    }
+    if (EnvelopeKeyManager.DEFAULT_KMS_INSTANCE_ID != kmsInstanceID) {
+      transitEngine = "/v1/" + kmsInstanceID;
+      if (!transitEngine.endsWith("/")) {
+        transitEngine += "/";
+      }
+      getKeyEndpoint = "/v1/" + kmsInstanceID;
+    }
+  }
+
+  @Override
+  public String wrapDataKeyInServer(byte[] dataKey, String masterKeyIdentifier) throws IOException, KeyAccessDeniedException, UnsupportedOperationException {
+    Map<String, String> writeKeyMap = new HashMap<String, String>(1);
+    final String dataKeyStr = Base64.getEncoder().encodeToString(dataKey);
+    writeKeyMap.put("plaintext", dataKeyStr);
+    String response = getContentFromTransitEngine(transitEngine + transitWrapEndpoint, buildPayload(writeKeyMap), masterKeyIdentifier);
+    String ciphertext = parseReturn(response, "ciphertext");
+    return ciphertext;
+  }
+
+  @Override
+  public byte[] unwrapDataKeyInServer(String wrappedKey, String masterKeyIdentifier) throws IOException, KeyAccessDeniedException, UnsupportedOperationException {
+    Map<String, String> writeKeyMap = new HashMap<String, String>(1);
+    writeKeyMap.put("ciphertext", wrappedKey);
+    String response = getContentFromTransitEngine(transitEngine + transitUnwrapEndpoint, buildPayload(writeKeyMap), masterKeyIdentifier);
+    String plaintext = parseReturn(response, "plaintext");
+    final byte[] key = Base64.getDecoder().decode(plaintext);
+    return key;
+  }
+
+  @Override
+  protected byte[] getKeyFromServer(String key) throws IOException, KeyAccessDeniedException, UnsupportedOperationException {
+    LOG.info("standardKeyIdentifier:  " + key);
+
+    final String endpoint = this.kmsURL + getKeyEndpoint;
+    Request request = new Request.Builder()
+      .url(endpoint)
+      .header(tokenHeader,  vaultToken)
+      .get().build();
+
+    String response = executeAndGetResponse(endpoint, request);
+
+    JsonNode keysNode = objectMapper.readTree(response).get("data").get("data");
+    byte[] matchingValue = null;
+    if (null != keysNode) {
+      matchingValue = keysNode.findValue(key).getBinaryValue();
+    }
+
+    if(null == matchingValue) {
+      throw new IOException("Failed to parse vault response. " + key + " not found."  + response);
+    }
+
+    return matchingValue;
+  }
+
+  private String buildPayload(Map<String, String> paramMap) throws IOException {
+    String jsonValue = objectMapper.writeValueAsString(paramMap);
+    return jsonValue;
+  }
+
+  private String getContentFromTransitEngine(String endPoint, String jPayload, String masterKeyIdentifier) throws IOException, KeyAccessDeniedException {
+    LOG.info("masterKeyIdentifier: " + masterKeyIdentifier);
+    String masterKeyID = masterKeyIdentifier;
+
+    final RequestBody requestBody = RequestBody.create(JSON_MEDIA_TYPE, jPayload);
+    Request request = new Request.Builder()
+            .url(this.kmsURL + endPoint + masterKeyID)
+            .header(tokenHeader,  vaultToken)
+            .post(requestBody).build();
+
+    return executeAndGetResponse(endPoint, request);
+  }
+
+  private String executeAndGetResponse(String endPoint, Request request) throws IOException, KeyAccessDeniedException {
+    Response response = null;
+    try {
+      response = httpClient.newCall(request).execute();
+      final String responseBody = response.body().string();
+      if (response.isSuccessful()) {
+        return responseBody;
+      } else {
+        if ((401 == response.code()) || (403 == response.code())) {
+          throw new KeyAccessDeniedException(responseBody);
+        }
+        throw new IOException("Vault call [" + endPoint + "] didn't succeed: " + responseBody);
+      }
+    } catch (IOException e) {
+      throw new IOException("Vault call [" + request.url().toString() + endPoint + "] didn't succeed", e);
+    } finally {
+      if (null != response) {
+        response.close();
+      }
+    }
+  }
+
+
+  private static String parseReturn(String response, String searchKey) throws IOException {
+    String matchingValue = objectMapper.readTree(response).findValue(searchKey).getTextValue();
+
+    if(null == matchingValue) {
+      throw new IOException("Failed to parse vault response. " + searchKey + " not found."  + response);
+    }
+    return matchingValue;
+  }
+
+}


### PR DESCRIPTION
KmsClient is per token and read/write KEK caches too.
Add default token value for InMemoryKMS, which has no tokens.
Use concurrentHashMap for caches with computeIfAbsent.
Add expiration using to the caches - both time-based and on-demand.
On expiration delete the per-token entries from caches.
Add method for cache invalidation per token.

Add abstract methods to be implemented by RemoteKmsClients.
